### PR TITLE
Throw error when building results in uncommitted changes

### DIFF
--- a/core/src/DefaultBuilder.ts
+++ b/core/src/DefaultBuilder.ts
@@ -153,6 +153,11 @@ class DefaultBuilder implements Builder {
       throw new Error(errors.join('\n====\n') || 'Unknown error while building')
     })
 
+    if (await doPromiseExec('git status --short', { cwd: workingDir })) {
+      await doPromiseExec('git reset --hard && git clean -fd', { cwd: workingDir })
+      throw new Error(`Building ${componentLibrary} resulted in uncommitted changes`)
+    }
+
     if (!fs.existsSync(path.join(workingDir, 'dist', 'stats-browser.json'))) {
       throw new Error(`Building ${componentLibrary} did not emit a browser stats file`)
     }

--- a/core/src/DefaultBuilder.ts
+++ b/core/src/DefaultBuilder.ts
@@ -154,8 +154,9 @@ class DefaultBuilder implements Builder {
     })
 
     if (await doPromiseExec('git status --short', { cwd: workingDir })) {
+      const diff = await doPromiseExec('git diff', { cwd: workingDir })
       await doPromiseExec('git reset --hard && git clean -fd', { cwd: workingDir })
-      throw new Error(`Building ${componentLibrary} resulted in uncommitted changes`)
+      throw new Error(`Building ${componentLibrary} resulted in unexpected changes\n${diff}`)
     }
 
     if (!fs.existsSync(path.join(workingDir, 'dist', 'stats-browser.json'))) {


### PR DESCRIPTION
If building a component library results in uncommitted changes, throw an error. 

Currently, those uncommitted changes hang around, and then if a new commit tries to modify the same file, we get an error that the local changes would be overwritten by merge. I think it would be preferable to fail the original build so that the committer realizes they need to push the changes that result from building.