### PR TITLE
check that wendigo query param equals 'true'

### DIFF
--- a/plugins/wendigo/src/WendigoPlugin.ts
+++ b/plugins/wendigo/src/WendigoPlugin.ts
@@ -23,7 +23,16 @@ class WendigoPlugin implements Plugin {
   // create errors if the same component/props is rendered repeatedly, which suggests a cache failure
   // before render, because props can possibly be modified during render
   onBeforeRender = ({ core, req, componentLibrary, component, props }: CoreHooks.OnBeforeRenderArgs) => {
-    if (req.query.wendigo !== 'true') {
+    let wendigo = true
+    if (req.query.wendigo) {
+      if (req.query.wendigo === 'false' || req.query.wendigo === '0') {
+        wendigo = false
+      } else if (req.query.wendigo !== 'true' && req.query.wendigo !== '1') {
+        core.log(`theia:wendigo ${componentLibrary}`, "WARNING: Unexpected value for wendigo. expected one of: 'false', 'true', '0', '1'")
+      }
+    }
+
+    if (!wendigo) {
       return Promise.resolve()
     }
 

--- a/plugins/wendigo/src/WendigoPlugin.ts
+++ b/plugins/wendigo/src/WendigoPlugin.ts
@@ -23,7 +23,7 @@ class WendigoPlugin implements Plugin {
   // create errors if the same component/props is rendered repeatedly, which suggests a cache failure
   // before render, because props can possibly be modified during render
   onBeforeRender = ({ core, req, componentLibrary, component, props }: CoreHooks.OnBeforeRenderArgs) => {
-    if (!req.query.wendigo) {
+    if (req.query.wendigo !== 'true') {
       return Promise.resolve()
     }
 


### PR DESCRIPTION
`req.query.XXX` is a string, so right now when a request is made with ?wendigo=0 or ?wendigo=false, req.query.wendigo is truthy and we still get wendigo errors.

This change would make it so that you only get wendigo errors with ?wendigo=true